### PR TITLE
Allow downloading OTA tars named AmberELEC instead of 351ELEC.

### DIFF
--- a/packages/amberelec/sources/scripts/351elec-upgrade
+++ b/packages/amberelec/sources/scripts/351elec-upgrade
@@ -11,15 +11,15 @@ DIR=$(realpath $(dirname $0))
 BAND=$(get_ee_setting updates.type)
 ORG=$(get_ee_setting updates.github.org)
 if [ "$ORG" == "" ]; then
-  ORG="351ELEC"
+  ORG="AmberELEC"
 fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
   if [ "$BAND" == "prerelease" ] || [ "$BAND" == "beta" ]; then
-    REPO=351ELEC-prerelease
+    REPO=AmberELEC-prerelease
   else
-    REPO=351ELEC
+    REPO=AmberELEC
   fi
 fi
 

--- a/packages/amberelec/sources/scripts/updatecheck
+++ b/packages/amberelec/sources/scripts/updatecheck
@@ -7,15 +7,15 @@ DIR=$(realpath $(dirname $0))
 BAND=$(get_ee_setting updates.type)
 ORG=$(get_ee_setting updates.github.org)
 if [ "$ORG" == "" ]; then
-  ORG=351ELEC
+  ORG=AmberELEC
 fi
 
 REPO=$(get_ee_setting updates.github.repo)
 if [ "$REPO" == "" ]; then
   if [ "$BAND" == "prerelease" ] || [ "$BAND" == "beta" ]; then
-    REPO=351ELEC-prerelease
+    REPO=AmberELEC-prerelease
   else
-    REPO=351ELEC
+    REPO=AmberELEC
   fi
 fi
 


### PR DESCRIPTION
# Summary
Existing pre-releases and releases will have 351ELEC in the name. New pre-releases will have AmberELEC in the name.  

Changes for OTA update script:
- OTA should be updated to look for .tar files with AmberELEC in the name
- If an update with AmberELEC is not found, fall back to 351ELEC for compatibility with old releases, pre-releases, etc.