### PR TITLE
Create tar files following 'old' naming convention for pre-releases

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -116,6 +116,20 @@ jobs:
           name: RG552-dev-main-${{ steps.date.outputs.date }}-${{steps.sha.outputs.sha}}
           path: |
             release/aarch64/RG552/
+
+      #NOTE: This can be removed after we no longer require old 351ELEC prereleases to be
+      # able to seamlessly upgrade to new AmberELEC prereleases
+      - name: Create backwards compatible 351ELEC tar and tar.sha256 files
+        if: github.event.action == 'release-prerelease'
+        run: |
+            for release in release/aarch64/RG*/*.tar*; do
+              echo "release: $release"
+              compatible_release=$(echo $release | sed 's|AmberELEC|351ELEC|g')
+              if [[ "$compatible_release" != "$release" ]]; then
+                echo "creating compatible tar: $compatible_release"
+                cp "$release" "$compatible_release" 
+              fi
+            done
       - name: Create pre-release as draft at first to hide during uploads
         if: github.event.action == 'release-prerelease'
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
# Summary
This allows 'old' 351ELEC prerelease software to update to new AmberELEC pre-releases by publishing duplicate 351ELEC .tar files following the old naming convention when prereleases are created.

Once we feel this is no longer needed (we have an 'AmberELEC' release, or everyone has updated), we can remove this code.