### PR TITLE
Adds a basic deadzone as default to the Mupen64PlusSA core for Nintendo 64

### DIFF
--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351MP.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351MP.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings

--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351P.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351P.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings

--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351V.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351V.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings

--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG552.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG552.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings


### PR DESCRIPTION
Deadzones were set to 0 across the board. Since we're defaulting deadzoning on some emulators, thought this one deserved some love.