### PR TITLE
Fix M64 not using user's config

### DIFF
--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/m64p.sh
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/m64p.sh
@@ -48,7 +48,7 @@ if [[ ! -f "$M64PCONF" ]]; then
 	cp $SHARE/mupen64plus.cfg $M64PCONF
 fi
 
-cp $SHARE/mupen64plus.cfg $TMP
+cp $M64PCONF $TMP
 
 RESOLUTION=$(batocera-resolution "currentResolution")
 echo ${RESOLUTION}


### PR DESCRIPTION
Don't copy the default config, copy the one the user (might've) modified.