### PR TITLE
Fixes "Show FPS" on Mupen64 Rice

### DIFF
--- a/packages/games/emulators/mupen64plussa/mupen64plussa-video-rice/patches/showFPS_fix.patch
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-video-rice/patches/showFPS_fix.patch
@@ -1,0 +1,22 @@
+diff --git a/src/OGLGraphicsContext.cpp b/src/OGLGraphicsContext.cpp
+index e4e57ba..e435acb 100644
+--- a/src/OGLGraphicsContext.cpp
++++ b/src/OGLGraphicsContext.cpp
+@@ -415,7 +415,7 @@ void COGLGraphicsContext::UpdateFrame(bool swaponly)
+ 
+    CoreVideo_GL_SwapBuffers();
+    
+-   /*if(options.bShowFPS)
++   if(options.bShowFPS)
+      {
+     static unsigned int lastTick=0;
+     static int frames=0;
+@@ -429,7 +429,7 @@ void COGLGraphicsContext::UpdateFrame(bool swaponly)
+          frames = 0;
+          lastTick = nowTick;
+       }
+-     }*/
++     }
+ 
+     glDepthMask(GL_TRUE);
+     OPENGL_CHECK_ERRORS;

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -73,6 +73,10 @@
 				<choice name="right stick c" value="rstickc"/>
 				<choice name="custom" value="custom"/>
 			</feature>
+			<feature name="Show FPS">
+				<choice name="on" value="enabled"/>
+				<choice name="off" value="disabled"/>
+			</feature>
 		</features>
 	</emulator>
 	<emulator name="hypseus_singe">

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -73,7 +73,7 @@
 				<choice name="right stick c" value="rstickc"/>
 				<choice name="custom" value="custom"/>
 			</feature>
-			<feature name="Show FPS">
+			<feature name="show fps">
 				<choice name="on" value="enabled"/>
 				<choice name="off" value="disabled"/>
 			</feature>


### PR DESCRIPTION
Added the feature in Emulation station (in the same style as others)
Uncommented the code in the Rice plugin that handled showing FPS (Added this as a patch)