### PR TITLE
Create an action that allows cleaning specific packages for all devices.

### DIFF
--- a/.github/workflows/clean-package.yaml
+++ b/.github/workflows/clean-package.yaml
@@ -1,0 +1,46 @@
+name: clean-package
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Comma separated list of packages to clean.  Ex: u-boot, retroarch"
+        required: true
+
+
+jobs:
+  clean:
+    strategy:
+      matrix:
+        runner: [main, pr]
+    runs-on:  ${{ matrix.runner }}
+    steps:
+      - uses: hmarr/debug-action@v2
+        name: debug
+      - uses: actions/checkout@v2
+        name: checkout
+        with:
+          clean: false
+          ref: "${{ steps.branch.outputs.branch }}"
+      - name: clean packages
+        run: |
+            set -e
+            #required for make clean to not require gcc
+            export LOCAL_CC=none
+            export HOST_NAME=buildserver
+            
+            PACKAGES="$(echo "${{github.event.inputs.package}}" | tr ',' ' ')"
+            DEVICES="RG351P RG351V RG351MP RG552"
+            echo "package: $PACKAGES"
+            for package in $PACKAGES; do
+              echo "removing: sources/$package"
+              rm -rf "sources/$package"
+              echo "removing: build*/$package-*"
+              rm -rf "build*/$package-*"
+              for device in $DEVICES; do
+                for arch in aarch64 arm; do
+                  echo "cleaning device: $device arch: $arch package: $package"
+                  DEVICE=$device ARCH=$arch PACKAGE=$package make package-clean
+                done
+              done
+            done
+


### PR DESCRIPTION
# Summary
Sometimes it's necessary to clean packages before they will build properly.  There are various cases why this happen.  `git clone or submodule init interrupted, etc`.

Ideally, we should try and make the build more resilient.  But in the mean time, this allows easily cleaning packages which are being problematic for all devices (and both 'pr' and 'dev/main' build workspaces) without logging into the build server directly.

To use, you must be an AmberELEC team member.
- Go to: https://github.com/AmberELEC/AmberELEC/actions/workflows/clean-package.yaml
- select 'Run Workflow' drop down.
- Set a list of packages to clean like: `gzdoom, gzdoom:host, retrorun` in `Comma separated list of packages to clean.`.  
- select 'run workflow' button.

As this could interrupt running jobs, the clean will be scheduled on both the 'main' and 'pr' runners when they are idle.