### PR TITLE
Cancel running PR's when a PR is merged/closed

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
       - dev
-    types: [opened, synchronize, ready_for_review, labeled]
+    types: [opened, closed, synchronize, ready_for_review, labeled]
 
 env:
   # This is used by 'make docker-*' commands to determine image to build with
@@ -28,8 +28,8 @@ jobs:
     timeout-minutes: 1440
     # Run on self-hosted runners with the 'pr' label
     runs-on: pr
-    # Don't run on drafts
-    if: github.event.pull_request.draft == false || github.event.label.name == 'build' 
+    # Don't run on drafts - skip 'closed' PR's
+    if: github.event.action != 'closed' && ( github.event.pull_request.draft == false || github.event.label.name == 'build' )
     steps:
       - uses: actions/checkout@v2
         name: checkout (pull request)


### PR DESCRIPTION
# Summary
Sometimes small PR's still have actions running after they are merged (if build was taking a long time or PR was approved quickly).  As this slows down the build which will immediately start for 'main/dev', it's sort of a pain.

This just makes it so that we run a build when a PR is 'closed' (merged or closed) that doesn't do anything.  Since we have our PR's setup to cancel any previously running build, this effectively means if a build is closed or merged, any running PR build will be cancelled.