### PR TITLE
Fix some versions of 8211CU being stuck in 'CD-ROM' mode

### DIFF
--- a/projects/Rockchip/packages/linux/udev.d/40-modeswitch.rules
+++ b/projects/Rockchip/packages/linux/udev.d/40-modeswitch.rules
@@ -8,4 +8,7 @@ SUBSYSTEM!="block", GOTO="end_modeswitch"
 # Atheros Wireless / Netgear WNDA3200
 ATTRS{idVendor}=="0cf3", ATTRS{idProduct}=="20ff", RUN+="/usr/bin/eject '/dev/%k'"
 
+# Realtek 8211CU Wifi AC USB
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="1a2b", RUN+="/usr/bin/eject '/dev/%k'"
+
 LABEL="end_modeswitch"


### PR DESCRIPTION
# Background
It appears some versions of the 8211CU usb wifi chipset are setup to provide their windows (or other) drivers by appearing as a CD-ROM when first booted.  This is obviously not super helpful for an embedded linux firmware that has drivers built in.

You can see the issue if you have ssh'd in via the inbuilt wifi card or hardwired ethernet and run `lsusb` (card will indicate it's in `CDROM` mode.) and the card will not have a blinking blue light.

# Fix
What this does is configure our udev rules to automatically eject the cd-rom for the 8211CU device when/if it appears.  After which, the wifi card will have a blinking blue light and should be functional (‘switched’ to normal operation mode).

I thought initially that the proper way to do this is via usb_modeswitch.  From: https://github.com/brektrou/rtl8821CU Ex: (add this to our udev rules)
```
ATTR{idVendor}=="0bda", ATTR{idProduct}=="1a2b", RUN+="/usr/sbin/usb_modeswitch -K -v 0bda -p 1a2b"
```

However, what I see is that though that usb_modeswitch command does work from the CLI it seems to hang and have issues when used in our udev rules.

What I tried is just using the same vendor/product as above and doing the 'eject' as already setup for `Atheros Wireless / Netgear WNDA3200` in our udev rules and it seems to work reliably.

I'm not sure exactly why eject is better - but I did see issues around the udevil-mount systemd service when using the usb_modeswitch approach, so perhaps udevil-mount already mounted the ISO/CDROM device and thus eject is preferable to usb_modeswitch and somehow performs the mode switch automagically, etc.  See: https://github.com/AmberELEC/AmberELEC/blob/dev/packages/sysutils/udevil/udev.d/95-udevil-mount.rules