### PR TITLE
Revert "Fix volume control to be faster"

### DIFF
--- a/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351MP/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -103,13 +103,11 @@ done
           fi
 
           INCREMENT_AMOUNT=1
-          if [[ "${REPEAT_NUM}" -gt "10" ]]; then
-             INCREMENT_AMOUNT=10
-          elif [[ "${REPEAT_NUM}" -gt "6" ]]; then
+          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
              INCREMENT_AMOUNT=5
-          elif [[ "${REPEAT_NUM}" -gt "3" ]]; then
+          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
              INCREMENT_AMOUNT=2
-          fi
+          fi   
           # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
             ${COMMAND} ${UP} ${INCREMENT_AMOUNT} > /dev/null

--- a/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG351V/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -105,13 +105,11 @@ done
           if [[ "$line" == ${REPEAT_PRESS} && $(( ${REPEAT_NUM} % ${REPEAT_MOD} )) != "0" ]]; then
              continue
           fi
-         
+
           INCREMENT_AMOUNT=1
-          if [[ "${REPEAT_NUM}" -gt "10" ]]; then
-             INCREMENT_AMOUNT=10
-          elif [[ "${REPEAT_NUM}" -gt "6" ]]; then
+          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
              INCREMENT_AMOUNT=5
-          elif [[ "${REPEAT_NUM}" -gt "3" ]]; then
+          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
              INCREMENT_AMOUNT=2
           fi
           # Run the commands to adjust volume/brightness

--- a/projects/Rockchip/devices/RG552/packages/odroidgoa-utils/sources/volume_sense.sh
+++ b/projects/Rockchip/devices/RG552/packages/odroidgoa-utils/sources/volume_sense.sh
@@ -102,14 +102,12 @@ done
              continue
           fi
 
-         INCREMENT_AMOUNT=1
-          if [[ "${REPEAT_NUM}" -gt "10" ]]; then
-             INCREMENT_AMOUNT=10
-          elif [[ "${REPEAT_NUM}" -gt "6" ]]; then
+          INCREMENT_AMOUNT=1
+          if [[ "${REPEAT_NUM}" -gt "75" ]]; then
              INCREMENT_AMOUNT=5
-          elif [[ "${REPEAT_NUM}" -gt "3" ]]; then
+          elif [[ "${REPEAT_NUM}" -gt "25" ]]; then
              INCREMENT_AMOUNT=2
-          fi
+          fi   
           # Run the commands to adjust volume/brightness
           if [[ "${line}" == ${VOL_UP} ]]; then
             ${COMMAND} ${UP} ${INCREMENT_AMOUNT} > /dev/null


### PR DESCRIPTION
This reverts commit f69bb67606d3ba53f49364d24682aa7856ae4fdb.

The previous change was added when 'softvol' plugin was used for 552 which meant the 'volume curve' was different vs using 'hardware' mixer.  Since we've gone back to hardware control - the volume got **even faster** at most normal volume ranges than in this PR and is a bit too touchy.

I think it may still make sense to slightly increase volume speed - but since the change needs to be reworked - IMO better to just revert this change so volume is more usable and then rework from there as makes sense.