### PR TITLE
Add .mid .mp3 .flac .ogg file types to mplayer

### DIFF
--- a/packages/amberelec/sources/scripts/mpv_video.sh
+++ b/packages/amberelec/sources/scripts/mpv_video.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+if [ "${1: -4}" == ".mid" ]
+then
+  PORT=$(aplaymidi -l | awk '/.*([0-9]*:[0-9]*) .*/ {a=$1} END{print a}')
+  echo Playing "${1}" on midi port $PORT
+  /usr/bin/aplaymidi -p $PORT "${1}"
+  exit 0
+fi
+
 /usr/bin/mpv --input-ipc-server=/tmp/mpvsocket "${1}"
 exit 0

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -2302,7 +2302,7 @@
 		<release>unknown</release>
 		<hardware>system</hardware>
 		<path>/storage/roms/mplayer</path>
-		<extension>.mp4 .mkv .avi .mov .wmv .m3u .mpg .ytb .twi .sh</extension>
+		<extension>.mp4 .mkv .avi .mov .wmv .m3u .mpg .ytb .twi .mid .mp3 .flac .sh</extension>
 		<command>/usr/bin/runemu.py --rom %ROM% --platform %SYSTEM% --emulator %EMULATOR% --core %CORE% --controllers "%CONTROLLERSCONFIG%"</command>
 		<platform>mplayer</platform>
 		<theme>mplayer</theme>

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -2302,7 +2302,7 @@
 		<release>unknown</release>
 		<hardware>system</hardware>
 		<path>/storage/roms/mplayer</path>
-		<extension>.mp4 .mkv .avi .mov .wmv .m3u .mpg .ytb .twi .mid .mp3 .flac .sh</extension>
+		<extension>.mp4 .mkv .avi .mov .wmv .m3u .mpg .ytb .twi .mid .mp3 .flac .ogg .sh</extension>
 		<command>/usr/bin/runemu.py --rom %ROM% --platform %SYSTEM% --emulator %EMULATOR% --core %CORE% --controllers "%CONTROLLERSCONFIG%"</command>
 		<platform>mplayer</platform>
 		<theme>mplayer</theme>


### PR DESCRIPTION
This extends built-in functionality of existing media player collection.

* adds other music types mpv already supports (.mp3 .flac .ogg) which I verified, see also link for all audio types supported.
* adds support for .mid type using alsa 'aplaymidi" utility (https://linux.die.net/man/1/aplaymidi)

https://github.com/mpv-player/mpv/blob/3458651010a68c2384a19ba485e81e22c825782f/player/external_files.c#L40
