### PR TITLE
Move the cursor to the great beyond

### DIFF
--- a/packages/games/tools/SDL2/patches/002-fix-cursor-showing-on-the-topleft-corner.patch
+++ b/packages/games/tools/SDL2/patches/002-fix-cursor-showing-on-the-topleft-corner.patch
@@ -1,0 +1,14 @@
+diff --git a/src/events/SDL_mouse.c b/src/events/SDL_mouse.c
+index 254182cc5..3f62dab15 100644
+--- a/src/events/SDL_mouse.c
++++ b/src/events/SDL_mouse.c
+@@ -199,6 +199,10 @@ SDL_MouseInit(void)
+ 
+     mouse->cursor_shown = SDL_TRUE;
+ 
++    //Set the mouse location far far away
++    mouse->x = 99999;
++    mouse->y = 99999;
++
+     return (0);
+ }


### PR DESCRIPTION
This basically moves the cursor far far away from the screen in its initializer. If an app actually uses it, it should reset.