### PR TITLE
Added a default deadzone of 4096,4096 across all consoles.

### DIFF
--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351MP.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351MP.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings

--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351P.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351P.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings

--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351V.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG351V.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings

--- a/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG552.cfg
+++ b/packages/games/emulators/mupen64plussa/mupen64plussa-core/config/mupen64plus-RG552.cfg
@@ -182,7 +182,7 @@ mouse = False
 # Scaling factor for mouse movements.  For X, Y axes.
 MouseSensitivity = "2.00,2.00"
 # The minimum absolute value of the SDL analog joystick axis to move the N64 controller axis value from 0.  For X, Y axes.
-AnalogDeadzone = "0,0"
+AnalogDeadzone = "4096,4096"
 # An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
 AnalogPeak = "32768,32768"
 # Digital button configuration mappings


### PR DESCRIPTION
This is the default I see across the config for other controllers, was wondering why ours was set to 0. 