### PR TITLE
ES retrorun: adds swap analog sticks and tate mode

### DIFF
--- a/packages/games/tools/retrorun/package.mk
+++ b/packages/games/tools/retrorun/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present AmberELEC (https://github.com/AmberELEC)
 
 PKG_NAME="retrorun"
-PKG_VERSION="9cc631f3f0b97d446ed5f3fe6a06a9bc2df37b92"
+PKG_VERSION="a9307a332143e137bb752c702373c4116387d9e0"
 PKG_LICENSE="GPLv2"
-PKG_SITE="https://github.com/AmberELEC/retrorun"
+PKG_SITE="https://github.com/navy1978/retrorun"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain libdrm libpng linux libevdev librga openal-soft"
 PKG_TOOLCHAIN="make"

--- a/packages/games/tools/retrorun/package.mk
+++ b/packages/games/tools/retrorun/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="retrorun"
 PKG_VERSION="a9307a332143e137bb752c702373c4116387d9e0"
 PKG_LICENSE="GPLv2"
-PKG_SITE="https://github.com/navy1978/retrorun"
+PKG_SITE="https://github.com/AmberELEC/retrorun"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain libdrm libpng linux libevdev librga openal-soft"
 PKG_TOOLCHAIN="make"

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -144,7 +144,7 @@ if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] |
 	sed -i "/^retrorun_tate_mode/d" ${RRCONF}
 	echo 'retrorun_tate_mode = auto' >> ${RRCONF}
 else
-	sed -i "/^retrorun_aspect_ratio/d" ${RRCONF}
+	sed -i "/^retrorun_tate_mode/d" ${RRCONF}
 	echo "retrorun_tate_mode = ${EES}" >> ${RRCONF}
 fi
 

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -50,7 +50,6 @@ else
 	echo "retrorun_auto_save = ${EES}" >> ${RRCONF}
 fi
 
-
 # Audio Buffer
 # Get configuration from distribution.conf and set to retrorun.cfg
 get_setting "audio_buffer"
@@ -110,7 +109,6 @@ else
 	sed -i "/^retrorun_fps_counter/d" ${RRCONF}
 	echo "retrorun_fps_counter = ${EES}" >> ${RRCONF}
 fi
-
 
 # Swap triggers
 # Get configuration from distribution.conf and set to retrorun.cfg

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -124,7 +124,31 @@ else
 	echo "retrorun_swap_l1r1_with_l2r2 = ${EES}" >> ${RRCONF}
 fi
 
-# Swap triggers
+# Swap analog sticks
+# Get configuration from distribution.conf and set to retrorun.cfg
+get_setting "swap_analog_sticks"
+echo "swap_analog_sticks:${EES}"
+if [ "${EES}" == "auto" ] || [ "${EES}" == "disabled" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
+	sed -i "/^retrorun_swap_sticks/d" ${RRCONF}
+	echo 'retrorun_swap_sticks = false' >> ${RRCONF}
+else
+	sed -i "/^retrorun_swap_sticks/d" ${RRCONF}
+	echo "retrorun_swap_sticks = ${EES}" >> ${RRCONF}
+fi
+
+# Tate Mode
+# Get configuration from distribution.conf and set to retrorun.cfg
+get_setting "tate_mode"
+echo "tate_mode:${EES}"
+if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
+	sed -i "/^retrorun_tate_mode/d" ${RRCONF}
+	echo 'retrorun_tate_mode = auto' >> ${RRCONF}
+else
+	sed -i "/^retrorun_aspect_ratio/d" ${RRCONF}
+	echo "retrorun_tate_mode = ${EES}" >> ${RRCONF}
+fi
+
+# Force FPS
 # Get configuration from distribution.conf and set to retrorun.cfg
 get_setting "force_fps"
 echo "force_fps:${EES}"

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -46,6 +46,15 @@
 			<choice name="on" value="true"/>
 			<choice name="off" value="false"/>
 		</feature>
+		<feature name="tate mode">
+			<choice name="enabled" value="enabled"/>
+			<choice name="reverted" value="reverted"/>
+			<choice name="disabled" value="disabled"/>
+		</feature>
+		<feature name="swap analog sticks">
+			<choice name="on" value="true"/>
+			<choice name="off" value="false"/>
+		</feature>
 		<feature name="force fps">
 			<choice name="on" value="true"/>
 			<choice name="off" value="false"/>


### PR DESCRIPTION
This is linked to this issue:
https://github.com/AmberELEC/AmberELEC/issues/969
Please dont merge . Need to test this and to change the retrorun repo (at the moment is pointing to mine)