### PR TITLE
Ensure docker image updated on build server when changed

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: main
     steps:
       #- uses: hmarr/debug-action@v2
       #  name: debug
@@ -39,3 +39,4 @@ jobs:
         run: |
          make docker-image-build
          make docker-image-push
+         make docker-image-pull


### PR DESCRIPTION
# Summary
Build image is not updated on build server when updated automatically

# Fix
Just run the image build on the build server and also pull it to ensure it matches exactly whats in the registry

# Testing
Built docker image via github action: https://github.com/pkegg/AmberELEC/actions/runs/8285603071/job/22673707668 and verified it was updated on that build server.

# Future considerations
This PR is an attempt to keep things as simple as possible.  The limitation would be if we ever move to a model where there are multiple build servers, we will need to adjust the logic so the 'make docker-image-pull' is done in it's own job dependent on the build step and run on all build servers (otherwise only one of multiple servers would get new image).  Alternately, move to a model where we do a pull before **every** build.  IMO It's not worth putting in that complexity now for something that might not happen.