### PR TITLE
retrorun: adds suport for more cores

### DIFF
--- a/packages/games/tools/retrorun/package.mk
+++ b/packages/games/tools/retrorun/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present AmberELEC (https://github.com/AmberELEC)
 
 PKG_NAME="retrorun"
-PKG_VERSION="a9307a332143e137bb752c702373c4116387d9e0"
+PKG_VERSION="1d717c3930df1bb1a93356d90c1226893393ab66"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/AmberELEC/retrorun"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/games/tools/retrorun/retrorun.cfg
+++ b/packages/games/tools/retrorun/retrorun.cfg
@@ -53,5 +53,19 @@ virtualjaguar_doom_res_hack = enabled
 virtualjaguar_pal = disabled
 virtualjaguar_usefastblitter = enabled
 virtualjaguar_bios = enabled
+# ---- PPSSPP ----
+ppsspp_cpu_core = JIT
+ppsspp_fast_memory = enabled
+ppsspp_frameskip = 0
+ppsspp_frameskiptype = Number of frames
+ppsspp_ignore_bad_memory_access = enabled
+ppsspp_internal_resolution = 480x272
+ppsspp_rendering_mode = buffered
+# ---- DUCKSTATION ----
+duckstation_CPU.Overclock = 100
+duckstation_Controller1.Type = AnalogController
+# ---- SWANSTATION ----
+swanstation_CPU_Overclock = 100
+swanstation_GPU_Renderer = Software
 # ---- RETRORUN RUNTIME SETTINGS ----
 

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -347,6 +347,61 @@ else
 	fi
 fi
 
+### PSX SWANSTATION ###
+echo 'Psx-swanstation settings.'
+# PSX CPU Overclock
+# Get configuration from distribution.conf and set to retrorun.cfg
+get_setting "psx_cpu_overclock"
+echo "psx_cpu_overclock:${EES}"
+if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
+	if [[ "${CORE}" == "swanstation" ]]; then
+		sed -i "/^swanstation_CPU.Overclock/d" ${RRCONF}
+		echo 'swanstation_CPU.Overclock = 100' >> ${RRCONF}
+	fi
+else
+	if [[ "${CORE}" == "swanstation" ]]; then
+		sed -i "/^swanstation_CPU.Overclock/d" ${RRCONF}
+	fi
+fi
+
+
+rendering mode
+
+
+
+### PPSSPP (PSP) ###
+echo 'PPSSPP settings.'
+# PPSSPP FrameSkip
+# Get configuration from distribution.conf and set to retrorun.cfg
+get_setting "frameskip"
+echo "frameskip:${EES}"
+if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
+	if [[ "${CORE}" == "ppsspp" ]]; then
+		sed -i "/^ppsspp_frameskip/d" ${RRCONF}
+		echo 'ppsspp_frameskip = 0' >> ${RRCONF}
+	fi
+else
+	if [[ "${CORE}" == "ppsspp" ]]; then
+		sed -i "/^ppsspp_frameskip/d" ${RRCONF}
+	fi
+fi
+
+# PPSSPP rendering mode
+# Get configuration from distribution.conf and set to retrorun.cfg
+get_setting "rendering_mode"
+echo "rendering_mode:${EES}"
+if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
+	if [[ "${CORE}" == "ppsspp" ]]; then
+		sed -i "/^ppsspp_rendering_mode=/d" ${RRCONF}
+		echo 'ppsspp_rendering_mode = buffered' >> ${RRCONF}
+	fi
+else
+	if [[ "${CORE}" == "ppsspp" ]]; then
+		sed -i "/^ppsspp_rendering_mode=/d" ${RRCONF}
+		echo "ppsspp_rendering_mode= = ${EES}" >> ${RRCONF}
+	fi
+fi
+
 ### BEETLE VB SETTINGS ###
 echo 'Beetle-vb settings.'
 # Beetle VB - Palette

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -366,11 +366,6 @@ else
 	fi
 fi
 
-
-rendering mode
-
-
-
 ### PPSSPP (PSP) ###
 echo 'PPSSPP settings.'
 # PPSSPP FrameSkip

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -344,6 +344,7 @@ if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] |
 else
 	if [[ "${CORE}" == "duckstation" ]]; then
 		sed -i "/^duckstation_CPU.Overclock/d" ${RRCONF}
+		echo "duckstation_CPU.Overclock = ${EES}" >> ${RRCONF}
 	fi
 fi
 
@@ -361,6 +362,7 @@ if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] |
 else
 	if [[ "${CORE}" == "swanstation" ]]; then
 		sed -i "/^swanstation_CPU.Overclock/d" ${RRCONF}
+		echo "swanstation_CPU.Overclock = ${EES}" >> ${RRCONF}
 	fi
 fi
 
@@ -383,6 +385,7 @@ if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] |
 else
 	if [[ "${CORE}" == "ppsspp" ]]; then
 		sed -i "/^ppsspp_frameskip/d" ${RRCONF}
+		echo "ppsspp_frameskip = ${EES}" >> ${RRCONF}
 	fi
 fi
 
@@ -398,7 +401,7 @@ if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] |
 else
 	if [[ "${CORE}" == "ppsspp" ]]; then
 		sed -i "/^ppsspp_rendering_mode=/d" ${RRCONF}
-		echo "ppsspp_rendering_mode= = ${EES}" >> ${RRCONF}
+		echo "ppsspp_rendering_mode = ${EES}" >> ${RRCONF}
 	fi
 fi
 

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -112,6 +112,27 @@
 					</feature>
 				</features>
 			</core>
+
+			<core name="ppsspp" features="">
+				<features>
+					<feature name="frameskip">
+						<choice name="0" value="0"/>
+						<choice name="1" value="1"/>
+						<choice name="2" value="2"/>
+						<choice name="3" value="3"/>
+						<choice name="4" value="4"/>
+						<choice name="5" value="5"/>
+						<choice name="6" value="6"/>
+						<choice name="7" value="7"/>
+						<choice name="8" value="8"/>
+						<choice name="9" value="9"/>
+					</feature>
+					<feature name="rendering mode">
+						<choice name="buffered" value="buffered"/>
+						<choice name="nonbuffered" value="nonbuffered"/>
+					</feature>
+				</features>
+			</core>
 			<core name="swanstation" features="">
 				<features>
 					<feature name="psx cpu overclock">

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -112,7 +112,6 @@
 					</feature>
 				</features>
 			</core>
-
 			<core name="ppsspp" features="">
 				<features>
 					<feature name="frameskip">

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -817,6 +817,12 @@
 					<core>smsplus</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -837,6 +843,12 @@
 					<core>genesis_plus_gx</core>
 					<core>picodrive</core>
 					<core>smsplus</core>
+				</cores>
+			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
 				</cores>
 			</emulator>
 		</emulators>
@@ -1670,6 +1682,11 @@
 					<core>picodrive</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1716,6 +1733,12 @@
 					<core>picodrive</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1737,6 +1760,12 @@
 					<core>picodrive</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1755,6 +1784,12 @@
 				<cores>
 					<core default="true">genesis_plus_gx</core>
 					<core>genesis_plus_gx_wide</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
 					<core>picodrive</core>
 				</cores>
 			</emulator>
@@ -1780,6 +1815,12 @@
 					<core>smsplus</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1801,6 +1842,12 @@
 					<core>picodrive</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1819,6 +1866,12 @@
 				<cores>
 					<core default="true">genesis_plus_gx</core>
 					<core>genesis_plus_gx_wide</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
 					<core>picodrive</core>
 				</cores>
 			</emulator>
@@ -1877,6 +1930,12 @@
 			<emulator name="retroarch">
 				<cores>
 					<core default="true">gearsystem</core>
+					<core>genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
+			<emulator name="retrorun">
+				<cores>
 					<core>genesis_plus_gx</core>
 					<core>picodrive</core>
 				</cores>

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -2318,25 +2318,25 @@
 			</emulator>
 		</emulators>
 	</system>
-        <system>
-                <name>microw8</name>
-                <fullname>MicroW8</fullname>
-                <manufacturer>Dennis Ranke</manufacturer>
-                <release>2022</release>
-                <hardware>computer</hardware>
-                <path>/storage/roms/microw8</path>
-                <extension>.wasm .uw8</extension>
-                <command>/usr/bin/runemu.py --rom %ROM% --platform %SYSTEM% --emulator %EMULATOR% --core %CORE% --controllers "%CONTROLLERSCONFIG%"</command>
-                <platform>microw8</platform>
-                <theme>microw8</theme>
-                <emulators>
-                        <emulator name="retroarch">
-                                <cores>
-                                        <core default="true">uw8</core>
-                                </cores>
-                        </emulator>
-                </emulators>
-        </system>
+	<system>
+		<name>microw8</name>
+		<fullname>MicroW8</fullname>
+		<manufacturer>Dennis Ranke</manufacturer>
+		<release>2022</release>
+		<hardware>computer</hardware>
+		<path>/storage/roms/microw8</path>
+		<extension>.wasm .uw8</extension>
+		<command>/usr/bin/runemu.py --rom %ROM% --platform %SYSTEM% --emulator %EMULATOR% --core %CORE% --controllers "%CONTROLLERSCONFIG%"</command>
+		<platform>microw8</platform>
+		<theme>microw8</theme>
+		<emulators>
+			<emulator name="retroarch">
+				<cores>
+					<core default="true">uw8</core>
+				</cores>
+			</emulator>
+		</emulators>
+	</system>
 	<system>
 		<name>lowresnx</name>
 		<fullname>LowRes NX</fullname>

--- a/packages/ui/emulationstation/config/es_systems.cfg
+++ b/packages/ui/emulationstation/config/es_systems.cfg
@@ -179,6 +179,12 @@
 					<core default="true">stella2014</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>stella</core>
+					<core>stella2014</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1511,6 +1517,11 @@
 					<core>ppsspp</core>
 				</cores>
 			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>ppsspp</core>
+				</cores>
+			</emulator>
 		</emulators>
 	</system>
 	<system>
@@ -1676,6 +1687,12 @@
 			<emulator name="retroarch">
 				<cores>
 					<core default="true">genesis_plus_gx</core>
+					<core>picodrive</core>
+				</cores>
+			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>genesis_plus_gx</core>
 					<core>picodrive</core>
 				</cores>
 			</emulator>
@@ -2027,6 +2044,14 @@
 					<core>bsnes_mercury_performance</core>
 					<core>bsnes_mercury_balanced</core>
 					<core>mesen-s</core>
+				</cores>
+			</emulator>
+			<emulator name="retrorun">
+				<cores>
+					<core>snes9x</core>
+					<core>snes9x2010</core>
+					<core>snes9x2002</core>
+					<core>snes9x2005_plus</core>
 				</cores>
 			</emulator>
 		</emulators>


### PR DESCRIPTION
Added support for :
SwanStation
Snes9x, Snes9x 2002, Snes9x 2005 Plus, Snes9x 2010
Genesis Plus GX
PicoDrive
PPSSPP
Stella, Stella2014


Please dont merge it yet , it needs to be tested