### PR TITLE
retrorun: ppsspp auto frameSkip core option added

### DIFF
--- a/packages/games/tools/retrorun/retrorun.cfg
+++ b/packages/games/tools/retrorun/retrorun.cfg
@@ -57,6 +57,7 @@ virtualjaguar_bios = enabled
 ppsspp_cpu_core = JIT
 ppsspp_fast_memory = enabled
 ppsspp_frameskip = 0
+ppsspp_auto_frameskip = disabled
 ppsspp_frameskiptype = Number of frames
 ppsspp_ignore_bad_memory_access = enabled
 ppsspp_internal_resolution = 480x272

--- a/packages/games/tools/retrorun/retrorun.sh
+++ b/packages/games/tools/retrorun/retrorun.sh
@@ -460,6 +460,22 @@ fi
 
 ### PPSSPP (PSP) ###
 echo 'PPSSPP settings.'
+# PPSSPP AutoFrameSkip
+get_setting "auto_frameskip"
+echo "auto_frameskip:${EES}"
+if [ "${EES}" == "auto" ] || [ "${EES}" == "false" ] || [ "${EES}" == "none" ] || [ "${EES}" == "0" ]; then
+	if [[ "${CORE}" == "ppsspp" ]]; then
+		sed -i "/^ppsspp_auto_frameskip/d" ${RRCONF}
+		echo 'ppsspp_auto_frameskip = disabled' >> ${RRCONF}
+	fi
+else
+	if [[ "${CORE}" == "ppsspp" ]]; then
+		sed -i "/^ppsspp_auto_frameskip/d" ${RRCONF}
+		echo "ppsspp_auto_frameskip = ${EES}" >> ${RRCONF}
+	fi
+fi
+
+
 # PPSSPP FrameSkip
 get_setting "frameskip"
 echo "frameskip:${EES}"

--- a/packages/ui/emulationstation/config/es_features.cfg
+++ b/packages/ui/emulationstation/config/es_features.cfg
@@ -154,6 +154,10 @@
 						<choice name="8" value="8"/>
 						<choice name="9" value="9"/>
 					</feature>
+					<feature name="auto frameskip">
+						<choice name="disabled" value="disabled"/>
+						<choice name="enabled" value="enabled"/>
+					</feature>
 					<feature name="rendering mode">
 						<choice name="buffered" value="buffered"/>
 						<choice name="nonbuffered" value="nonbuffered"/>


### PR DESCRIPTION
Added PPSSPP core option "ppsspp_auto_frameskip" set to disabled as default but now available in ES menu