### PR TITLE
fix(waf): build host tool from maintained source

### DIFF
--- a/packages/python/devel/waf/package.mk
+++ b/packages/python/devel/waf/package.mk
@@ -3,13 +3,15 @@
 
 PKG_NAME="waf"
 PKG_VERSION="2.0.24"
-PKG_SHA256="6b78a3594540b232a154f64c4eb7e21f28e4e073c7e1605e4b9977519a6cb89e"
+PKG_SHA256="599ab1903b6f12f0683878d2cd4f73546e0ce26031efd05f3fbe5178e4ef8cda"
 PKG_LICENSE="MIT"
 PKG_SITE="https://waf.io"
-PKG_URL="https://waf.io/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_URL="https://gitlab.com/ita1024/waf/-/archive/waf-${PKG_VERSION}/waf-waf-${PKG_VERSION}.tar.bz2"
+PKG_SOURCE_DIR="waf-waf-${PKG_VERSION}"
 PKG_LONGDESC="The Waf build system"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_host() {
+  (cd ${PKG_BUILD} && /usr/bin/python3 ./waf-light --make-waf --python=/usr/bin/python3 --interpreter='#!/usr/bin/python3')
   cp -pf ${PKG_BUILD}/waf ${TOOLCHAIN}/bin/
 }


### PR DESCRIPTION
## What changed

- Fetch Waf 2.0.24 from its maintained GitLab source archive.
- Generate the standalone `waf` executable with the host Python interpreter before installing it into the host toolchain.

## Why

The previous download location is no longer reliable. Building the replacement source archive through the generated toolchain Python also fails because that interpreter has no `bz2` module, which Waf uses while creating the standalone executable.

Using `/usr/bin/python3` for this host-side generation avoids depending on target-toolchain Python modules.

## Validation

- Waf host package builds and installs successfully.
- A complete AmberELEC RG351MP image build completed successfully.
