### PR TITLE
fix(RTL815x): install Realtek USB Ethernet driver

### DIFF
--- a/projects/Rockchip/packages/RTL815x/package.mk
+++ b/projects/Rockchip/packages/RTL815x/package.mk
@@ -22,4 +22,11 @@ make_target() {
 makeinstall_target() {
   mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
   find ${PKG_BUILD}/ -name \*.ko -not -path '*/\.*' -exec cp {} ${INSTALL}/$(get_full_module_dir)/${PKG_NAME} \;
+
+  mkdir -p ${INSTALL}/usr/lib/udev/rules.d
+  cp ${PKG_BUILD}/50-usb-realtek-net.rules ${INSTALL}/usr/lib/udev/rules.d
+}
+
+post_install() {
+  rm -f ${INSTALL}/$(get_full_module_dir)/kernel/drivers/net/usb/r8152.ko
 }


### PR DESCRIPTION
## What changed

- Install the upstream `50-usb-realtek-net.rules` file supplied with the external RTL815x driver.
- Remove the older in-tree `r8152.ko` when installing the external driver.

## Why

Some RTL8152/RTL8153/RTL8155/RTL8156 devices need the supplied udev rule to select USB configuration 1 before binding to `r8152`.

The image previously contained two modules named `r8152.ko`. `depmod` selected the older kernel 4.4 module and ignored the newer external driver, defeating the purpose of the RTL815x package.

## Validation

- `modules.dep` resolves `r8152` to `RTL815x/r8152.ko`.
- The in-tree duplicate is absent from the resulting image.
- The udev rule and aliases for `0bda:8153` are present.
- Ethernet connectivity was verified on an RG351MP with a Realtek RTL8153 adapter (`0bda:8153`).
- A complete AmberELEC RG351MP image build completed successfully.
