### PR TITLE
build: support native AArch64 build hosts

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -422,7 +422,17 @@ EOF
 }
 
 create_meson_conf() {
-  local root properties c_flags cpp_flags ld_flags
+  local root properties c_flags cpp_flags ld_flags exe_wrapper needs_exe_wrapper
+  exe_wrapper=""
+  needs_exe_wrapper=""
+
+  if [ "$1" = "target" ] &&
+     [ "${HOST_NAME%%-*}" = "aarch64" ] &&
+     [ "${TARGET_ARCH}" = "aarch64" ]; then
+    exe_wrapper="exe_wrapper = ['$SYSROOT_PREFIX/usr/lib/ld-linux-aarch64.so.1', '--library-path', '$SYSROOT_PREFIX/usr/lib']"
+    needs_exe_wrapper="needs_exe_wrapper = true"
+  fi
+
   case "$1" in
     target|init)
       root="$SYSROOT_PREFIX/usr"
@@ -448,6 +458,7 @@ ar = '$AR'
 strip = '$STRIP'
 pkgconfig = '$PKG_CONFIG'
 llvm-config = '$SYSROOT_PREFIX/usr/bin/llvm-config-host'
+$exe_wrapper
 
 [host_machine]
 system = 'linux'
@@ -463,6 +474,7 @@ $(python3 -c "import os, shlex; print('cpp_link_args = {}'.format(shlex.split(''
 
 [properties]
 root = '$root'
+$needs_exe_wrapper
 ${!properties}
 EOF
 }

--- a/packages/tools/sysutils/freeimage/package.mk
+++ b/packages/tools/sysutils/freeimage/package.mk
@@ -10,6 +10,7 @@ PKG_URL="${SOURCEFORGE_SRC}/${PKG_NAME}/FreeImage${PKG_VERSION}.zip"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_SOURCE_DIR="FreeImage"
 PKG_LONGDESC="FreeImage library"
+PKG_BUILD_FLAGS="+pic"
 
 pre_make_target() {
   export CXXFLAGS="${CXXFLAGS} -Wno-narrowing -std=c++11"

--- a/projects/Rockchip/packages/RTL8852BU/package.mk
+++ b/projects/Rockchip/packages/RTL8852BU/package.mk
@@ -11,16 +11,41 @@ PKG_NEED_UNPACK="${LINUX_DEPENDS}"
 PKG_LONGDESC="Realtek RTL8852BU/RTL8832BU Linux 4.4-5.x driver"
 PKG_IS_KERNEL_PKG="yes"
 
+# Shorten Kbuild paths on AArch64 hosts to stay below ARG_MAX.
+RTL8852BU_SHORT_BUILD="/tmp/amberelec-${DEVICE}-rtl8852bu"
+
 pre_make_target() {
   unset LDFLAGS
+
+  if [ "${HOST_NAME%%-*}" = "aarch64" ]; then
+    rm -f "${RTL8852BU_SHORT_BUILD}"
+    ln -s "${PKG_BUILD}" "${RTL8852BU_SHORT_BUILD}"
+  fi
 }
 
 make_target() {
+  local module_path_args=()
+
+  if [ "${HOST_NAME%%-*}" = "aarch64" ]; then
+    module_path_args=(
+      M="${RTL8852BU_SHORT_BUILD}"
+      OUT_DIR="${RTL8852BU_SHORT_BUILD}"
+      TopDIR="${RTL8852BU_SHORT_BUILD}"
+    )
+  fi
+
   make V=1 \
        ARCH=${TARGET_KERNEL_ARCH} \
        KSRC=$(kernel_path) \
+       "${module_path_args[@]}" \
        CROSS_COMPILE=${TARGET_KERNEL_PREFIX} \
        CONFIG_POWER_SAVING=n
+}
+
+post_make_target() {
+  if [ "${HOST_NAME%%-*}" = "aarch64" ]; then
+    rm -f "${RTL8852BU_SHORT_BUILD}"
+  fi
 }
 
 makeinstall_target() {


### PR DESCRIPTION
Adds support for building AmberELEC on native AArch64 hosts.

Tested with RG552 on Ubuntu 20.04 AArch64.